### PR TITLE
add system property to skip colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 *~
+.classpath
+.project
+.settings/

--- a/README.adoc
+++ b/README.adoc
@@ -31,6 +31,13 @@ Handled colors are configurable, here are the defaults (key and values):
 
 You need to edit ${maven.home}/conf/logging/simplelogger.properties file.
 
+= Skip colors
+
+For batch executions or when redirecting output, you can disable colors by setting property `maven.colors.skip` to true
+----
+MAVEN_OPTS="$MAVEN_OPTS -Dmaven.colors.skip=true" mvn compile
+----
+
 = Sample
 
 image::screenshot.png[]

--- a/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -46,7 +46,7 @@ import java.util.Properties;
 import static org.fusesource.jansi.Ansi.ansi;
 
 public class SimpleLogger extends MarkerIgnoringBase {
-
+    private static final boolean skipColors = Boolean.getBoolean("maven.colors.skip");
     private static final long serialVersionUID = -632788891211436180L;
     private static final String CONFIGURATION_FILE = "simplelogger.properties";
 
@@ -354,8 +354,13 @@ public class SimpleLogger extends MarkerIgnoringBase {
     }
 
     private void dump(Ansi.Color color, String line) {
-        TARGET_STREAM.println(ansi().fg(color).a(line).reset());
-        TARGET_STREAM.flush();
+        if (!skipColors) {
+            TARGET_STREAM.println(ansi().fg(color).a(line).reset());
+            TARGET_STREAM.flush();
+        } else {
+            TARGET_STREAM.println(line);
+            TARGET_STREAM.flush();
+        }
     }
 
     private String getFormattedDate() {


### PR DESCRIPTION
For batch executions or when using output redirection it is useful to skip the extra characters of colorization.
